### PR TITLE
Responsive Design of Home Page

### DIFF
--- a/src/pages/user/HomePage.jsx
+++ b/src/pages/user/HomePage.jsx
@@ -43,7 +43,7 @@ function LandingPage() {
     <div className="z-[-2] h-screen bg-custom-gradient w-full flex flex-col items-center font-VarelaRound">
         {stars}
             <div className="flex flex-col items-center justify-between h-[70vh] gap-2.5">
-                <div className="flex flex-col items-center h-fit gap-2">
+                <div className="flex flex-col items-center gap-2 max-h-[650px] -mt-[40px]">
                     <div className="mt-[50px] relative">
                         <div className="absolute top-3 right-[-2rem] flex flex-row items-start">
                             <PiPawPrintFill className="text-white text-[2.2rem] transform rotate-45 " />


### PR DESCRIPTION
I have added a max height of the container which is thus disallowing the footer underneath to cover up the buttons. As and when the height resizes, the footer changes. 
Here's the final look in the desktop view: 
![Screenshot (27)](https://github.com/Innovateninjas/Paws-frontend/assets/112813772/0b15dc16-e086-4d74-853b-3c48ea469998)

#319  issue resolved
