### PR TITLE
BugFix for Password input field

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,10 @@ body {
 * {
   box-sizing: inherit;
 }
+input::-ms-reveal,
+input::-ms-clear {
+  display: none;
+}
 
 @font-face {
   font-family: 'VarelaRound';


### PR DESCRIPTION
## Description
Since there is a overwriting of password in password input and I faced it in only edge so I added only few line of CSS which hide the eye icon which was overwritten



## Screenshots / GIFs (if applicable)
In Microsoft Edge -

https://github.com/user-attachments/assets/940e3f28-1692-440f-8329-86f12d150f14




## Checklist:
- [X] I have performed a self-review of my code
- [X] I have added/updated relevant documentation (if needed)
- [X] I have tested the changes locally and they function as expected
- [X] I have ensured my code follows the project's coding standards




